### PR TITLE
Add /recieve

### DIFF
--- a/command-processor.js
+++ b/command-processor.js
@@ -121,7 +121,7 @@ const main = module.exports = (_mes) => (msg, from, sudo = from) => {
 
         case "recieve":
           const [torname, torque = ''] = args.shift().split('/'), tori = args.shift()
-          const recieve$_regex = new RegExp(`^${name}\\[reciever(?:\\.\\w{6}(?<=${torque}))?\\]$`)
+          const recieve$_regex = new RegExp(`^${torname}\\[reciever(?:\\.\\w{6}(?<=${torque}))?\\]$`)
           for (let sock in r.list) {
             if (recieve$_regex.exec(sock[r.s].name)) {
               mes(sudo, "cmdresp", `Matched reciever ${sock[r.s].name}.`)

--- a/command-processor.js
+++ b/command-processor.js
@@ -122,8 +122,7 @@ const main = module.exports = (_mes) => (msg, from, sudo = from) => {
         case "recieve":
           const [torname, torque = ''] = args.shift().split('/'), tori = args.shift()
           const recieve$_regex = new RegExp(`^${name}\\[reciever(?:\\.\\w{6}(?<=${torque}))?\\]$`)
-          for (let sock in r.list) {/;"
-            ?."
+          for (let sock in r.list) {
             if (recieve$_regex.exec(sock[r.s].name)) {
               mes(sudo, "cmdresp", `Matched reciever ${sock[r.s].name}.`)
               sock.emit("linkout", tori)

--- a/command-processor.js
+++ b/command-processor.js
@@ -120,9 +120,10 @@ const main = module.exports = (_mes) => (msg, from, sudo = from) => {
           r.io.emit("edit", `${args.shift()}`, r.t.message((d.getHours() + 8 + 12) % 24, d.getMinutes(), args.shift(), args.join(" "), edid)); return true;
 
         case "recieve":
-          const torname = args.shift(), tori = args.shift()
-          const recieve$_regex = new RegExp(`^\\${name}\\[reciever(?:\\.\\w{4})?\\]$`)
-          for (let sock in r.list) {
+          const [torname, torque = ''] = args.shift().split('/'), tori = args.shift()
+          const recieve$_regex = new RegExp(`^${name}\\[reciever(?:\\.\\w{6}(?<=${torque}))?\\]$`)
+          for (let sock in r.list) {/;"
+            ?."
             if (recieve$_regex.exec(sock[r.s].name)) {
               mes(sudo, "cmdresp", `Matched reciever ${sock[r.s].name}.`)
               sock.emit("linkout", tori)

--- a/command-processor.js
+++ b/command-processor.js
@@ -121,16 +121,16 @@ const main = module.exports = (_mes) => (msg, from, sudo = from) => {
 
         case "recieve":
           const [torname, torque = ''] = args.shift().split('/'), tori = args.shift()
-          const recieve$_regex = new RegExp(`^${torname}\\[reciever(?:\\.\\w{6}(?<=${torque}))?\\]$`)
-          for (let sock in r.list) {
+          const recieve$_regex = new RegExp(`^${torname}\\[reciever(?:\\.\\w{5}(?<=${torque}))?\\]$`)
+          for (let sock of r.list) {
             if (recieve$_regex.exec(sock[r.s].name)) {
               mes(sudo, "cmdresp", `Matched reciever ${sock[r.s].name}.`)
               sock.emit("linkout", tori)
               return true
             }
           }
-          mes(sudo, "cmdresp", `Error 404: ${torname} not found!.`)
-          
+          mes(sudo, "cmdresp", `Error 404: ${torname} not found!`)
+          return true
         case "linkout":
           let tolink = args.shift();
           let tol = r.rnames[tolink];
@@ -375,7 +375,7 @@ const main = module.exports = (_mes) => (msg, from, sudo = from) => {
       // your mod skills as a trial mod   //
       // and you might get the real one.  //
 			// I just aligned those three lines //
-			// by accident, but these two       //
+			// by accident, but these three     //
 		  // messed everything up.            //
       // ===================================
       case process.env.SELF_OP_COMMAND || "_nowop":

--- a/command-processor.js
+++ b/command-processor.js
@@ -119,6 +119,18 @@ const main = module.exports = (_mes) => (msg, from, sudo = from) => {
           edid = args.shift();
           r.io.emit("edit", `${args.shift()}`, r.t.message((d.getHours() + 8 + 12) % 24, d.getMinutes(), args.shift(), args.join(" "), edid)); return true;
 
+        case "recieve":
+          const torname = args.shift(), tori = args.shift()
+          const recieve$_regex = new RegExp(`^\\${name}\\[reciever(?:\\.\\w{4})?\\]$`)
+          for (let sock in r.list) {
+            if (recieve$_regex.exec(sock[r.s].name)) {
+              mes(sudo, "cmdresp", `Matched reciever ${sock[r.s].name}.`)
+              sock.emit("linkout", tori)
+              return true
+            }
+          }
+          mes(sudo, "cmdresp", `Error 404: ${torname} not found!.`)
+          
         case "linkout":
           let tolink = args.shift();
           let tol = r.rnames[tolink];
@@ -126,13 +138,13 @@ const main = module.exports = (_mes) => (msg, from, sudo = from) => {
           if (tol) {
             tol.emit("linkout", link);
             mes(sudo, "cmdresp", `Ok, ${tolink} is on ${link} now.`, r.SYS_ID);
-            mes(tolink, "alert", `You were <a href="${link}" target=_blank>linked</a> by ${tolink[r.s].name}`, r.SYS_ID)
+            mes(tolink, "alert", `You were <a href="${link}" target=_blank>linked</a> by ${from[r.s].name}`, r.SYS_ID)
           } else {
             mes(sudo, "cmdresp", `Error 404: ${tolink} not found!`, r.SYS_ID);
           } return true;
 
         case "code":
-          from.emit("linkout", "https://github.dev/nomorenotes/nomorenotes")
+          from.emit("linkout", "https://replit.com/@PoolloverNathan/nomorenotes")
           mes(from, "cmdresp", "You are now coding!")
           return true;
         case "op":

--- a/iomodule.js
+++ b/iomodule.js
@@ -129,7 +129,7 @@ const format_msg = module.exports.format_msg = msg => msg
   .replace(/(?!document)c\W*u\W*m/ig, "ice cream")
   .replace(/p\W*[ro0]?\W*[r0o]\W*n/ig, "corn")
   .replace(/h\W*w?\W*[3e]\W*n\W*t\W*a?\W*[1li]/ig, "hitmen")
-  .replace(/r\/([a-zA-Z0-9]{3,21})/, (_match, sub) => `<a href="//bob.fr.to/r/${sub}" target=_blank>r/${sub}</a>`) // autolink subs
+  .replace(/\{r\/([a-zA-Z0-9]{3,21})\}/, (_match, sub) => `<a href="//bob.fr.to/r/${sub}" target=_blank>r/${sub}</a>`) // autolink subs
   
 /*.replace(/</g, "&lt;")
 .replace(/>/g, "&gt;")


### PR DESCRIPTION
This adds a command that auto-matches the first #153 sender name corresponding to a URL. This makes using recievers easier, because if someone closes a reciever mid-command, you won't have to edit your command. Additionally, a slash (`/`) can be added, followed by a suffix that the reciever slug (the part after the period) must match.