### PR TITLE
Embeddable reciever page

### DIFF
--- a/chat/module.js
+++ b/chat/module.js
@@ -12,4 +12,7 @@ module.exports = (app) => {
     res.render('recieve', req.params)
   })
   app.get('/chat/recieve.js', (req, res) => res.sendFile(__dirname + '/recieve.js'))
+  app.get('/chat/embed-recieve/:name', (req, res) => {
+    res.render('embed-recieve', req.params)
+  })
 }

--- a/command-processor.js
+++ b/command-processor.js
@@ -124,7 +124,7 @@ const main = module.exports = (_mes) => (msg, from, sudo = from) => {
           const recieve$_regex = new RegExp(`^${torname}\\[reciever(?:\\.\\w{5}(?<=${torque}))?\\]$`)
           for (let sock of r.list) {
             if (recieve$_regex.exec(sock[r.s].name)) {
-              mes(sudo, "cmdresp", `Matched reciever ${sock[r.s].name}.`)
+              mes(sudo, "cmdresp", `Ok, ${torname}'s reciever ${sock[r.s].name.replace(torname, "").replace('reciever.', "")} is on ${tori} now.`)
               sock.emit("linkout", tori)
               return true
             }

--- a/public/cors/embed-recieve.js
+++ b/public/cors/embed-recieve.js
@@ -1,0 +1,14 @@
+url => {
+  const iframe = document.createElement("iframe")
+  Object.assign(iframe.style, {
+    // width: 0, height: 0,
+    position: "absolute",
+    left: 0, top: 0,
+    opacity: 0,
+    transform: "translate(-100%, -100%)"
+  })
+
+  iframe.src = url
+  document.body.appendChild(iframe)
+  // alert(iframe)
+}

--- a/public/embed-recieve.js
+++ b/public/embed-recieve.js
@@ -1,0 +1,3 @@
+window.onerror ??= (_msg, _url, _line, _col, err) => alert(err.stack)
+const url = `${location.origin}/chat/recieve/${s.innerText}`
+a.href = `javascript:fetch("${location.origin}/cors/embed-recieve.js").then(res=>res.text()).then(data=>eval(data)("${url}"))`

--- a/server.js
+++ b/server.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const cors = require('cors');
 const { execSync } = require("child_process")
 const { hash: NOCRYPT_hash } = require("xxhash")
 const { auth, requiresAuth, attemptSilentLogin } = require('express-openid-connect');
@@ -203,6 +204,7 @@ http.listen(port, function() {
 	console.log('listening on *:' + port);
 });
 
+app.use("/cors", cors(), express.static("public/cors"))
 app.use(express.static("public"))
 app.use("/bandruf", requiresAuth(), express.static("bandruf"))
 

--- a/views/embed-recieve.pug
+++ b/views/embed-recieve.pug
@@ -1,0 +1,3 @@
+a#a Embed-recieve
+span(hidden)#s= name
+script(src="/embed-recieve.js")


### PR DESCRIPTION
This pull request allows embedding the `/chat/recieve/:name` page via the use of a bookmarklet. The bookmarklet is installable at `/chat/embed-recieve/:name`, and when activated injects a hidden iframe that acts as the reciever page. This also introduces a folder for storing CORS-enabled resources, such as the script that creates the iframe.