### PR TITLE
CORS proxy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2779,20 +2779,6 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -7975,13 +7961,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
-    },
-    "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4875,9 +4875,9 @@
       }
     },
     "node_modules/pure-rand": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.0.tgz",
-      "integrity": "sha512-rLSBxJjP+4DQOgcJAx6RZHT2he2pkhQdSnofG5VWyVl6GRq/K02ISOuOLcsMOrtKDIJb8JN2zm3FFzWNbezdPw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.2.tgz",
+      "integrity": "sha512-6Yg0ekpKICSjPswYOuC5sku/TSWaRYlA0qsXqJgM/d/4pLPHPuTxK7Nbf7jFKzAeedUhR8C7K9Uv63FBsSo8xQ==",
       "dev": true,
       "funding": [
         {
@@ -9542,9 +9542,9 @@
       }
     },
     "pure-rand": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.0.tgz",
-      "integrity": "sha512-rLSBxJjP+4DQOgcJAx6RZHT2he2pkhQdSnofG5VWyVl6GRq/K02ISOuOLcsMOrtKDIJb8JN2zm3FFzWNbezdPw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.2.tgz",
+      "integrity": "sha512-6Yg0ekpKICSjPswYOuC5sku/TSWaRYlA0qsXqJgM/d/4pLPHPuTxK7Nbf7jFKzAeedUhR8C7K9Uv63FBsSo8xQ==",
       "dev": true
     },
     "qs": {

--- a/server.js
+++ b/server.js
@@ -89,7 +89,6 @@ app.get("/setup", requiresAuth(), (req, res) => {
 })
 const eaglerUrl =
   "https://raw.githubusercontent.com/PoolloverNathan/eaglercraft/main/stable-download/Offline_Download_Version.html"
-const eaglerLog = logger.extend("eagler")
 app.get(["/eagler", "/eagler/dl"], (req, res) => {
   fget(req, res, eaglerUrl, req.originalUrl.includes("dl"))
 })
@@ -103,6 +102,7 @@ function white(base, ...keys) {
   keys.flat().forEach(key => copy[key] = base[key])
   return copy
 }
+const fgetLog = logger.extend("fget")
 const fgetwhite = 'headers:method  '.split`:`
 function fget(req, res, url, download=false) {
   url = new URL(url)
@@ -111,7 +111,7 @@ function fget(req, res, url, download=false) {
   const rqToken = (Math.random().toString().split(".")[1] || "")
     .slice(0, 4)
     .padStart(4, 0)
-  const log = eaglerLog.extend(rqToken)
+  const log = fgetLog.extend(rqToken)
   log(`Downloading [${url}, download=${download}]`)
   if (download) {
     log("Setting Content-Disposition");

--- a/server.js
+++ b/server.js
@@ -93,20 +93,20 @@ app.get(["/eagler", "/eagler/dl"], (req, res) => {
   fget(req, res, eaglerUrl, req.originalUrl.includes("dl"))
 })
 function omit(base, ...keys) {
-  const copy = {...base}
-  keys.flat().forEach(key => delete copy[key])
+  const copy = { ...base }
+  keys.flat().forEach((key) => delete copy[key])
   return copy
 }
 function white(base, ...keys) {
   const copy = {}
-  keys.flat().forEach(key => copy[key] = base[key])
+  keys.flat().forEach((key) => (copy[key] = base[key]))
   return copy
 }
 const fgetLog = logger.extend("fget")
-const fgetwhite = 'headers:method  '.split`:`
-function fget(req, res, url, download=false) {
+const fgetwhite = "headers:method  ".split`:`
+function fget(req, res, url, download = false) {
   url = new URL(url)
-  const r = request(url/*, white(req, fgetwhite)*/)
+  const r = request(url /*, white(req, fgetwhite)*/)
   //req.pipe(r)
   const rqToken = (Math.random().toString().split(".")[1] || "")
     .slice(0, 4)
@@ -114,7 +114,7 @@ function fget(req, res, url, download=false) {
   const log = fgetLog.extend(rqToken)
   log(`Downloading [${url}, download=${download}]`)
   if (download) {
-    log("Setting Content-Disposition");
+    log("Setting Content-Disposition")
     res.setHeader("Content-Disposition", 'attachment; filename="eagler.html"')
   }
   r.on("response", (message) => {
@@ -413,26 +413,30 @@ app.get("/me", requiresAuth(), ({ oidc }, res) => {
   })
 })
 
-app.get('/cp/64/:data', cors(), (req, res) => {
-  const url = atob(req.params.data.replace('-', '/'))
+app.get("/cp/64/:data", cors(), (req, res) => {
+  const url = atob(req.params.data.replace("-", "/"))
   console.log("CORS proxy v2")
   fget(req, res, url)
 })
-app.get('/cp/x:byte([\da-z]{2})/:data', cors(), (req, res, next) => {
+app.get("/cp/x:byte([da-z]{2})/:data", cors(), (req, res, next) => {
   const byte = parseInt(req.params.byte, 16)
   console.log("CORS proxy v3")
   if (byte < 0 || byte > 255) next()
-  const buf = Buffer.from(req.params.data.replace('-', '/'), 'base64')
+  const buf = Buffer.from(req.params.data.replace("-", "/"), "base64")
   for (let i = 0; i < buf.length; i++) {
     buf[i] ^= byte
   }
   fget(req, res, buf.toString())
 })
-app.get(['/cp/:protocol/:domain/*', '/cp/:protocol/:domain'], cors(), (req, res) => {
-  const { protocol, domain, 0: path = '' } = req.params
-  console.log("CORS proxy v1")
-  fget(req, res, `${protocol}://${domain}/${path}`)
-})
+app.get(
+  ["/cp/:protocol/:domain/*", "/cp/:protocol/:domain"],
+  cors(),
+  (req, res) => {
+    const { protocol, domain, 0: path = "" } = req.params
+    console.log("CORS proxy v1")
+    fget(req, res, `${protocol}://${domain}/${path}`)
+  }
+)
 
 // require("./auth0.js")(app, io)
 // app.use("/auth0", require("./auth0.js")(io))

--- a/server.js
+++ b/server.js
@@ -91,14 +91,17 @@ const eaglerUrl =
   "https://raw.githubusercontent.com/PoolloverNathan/eaglercraft/main/stable-download/Offline_Download_Version.html"
 const eaglerLog = logger.extend("eagler")
 app.get(["/eagler", "/eagler/dl"], (req, res) => {
-  const r = request(eaglerUrl)
+  fget(req, res, eaglerUrl, req.originalUrl.includes("dl"))
+})
+function fget(req, res, url, download=false) {
+  const r = request(url)
   const rqToken = (Math.random().toString().split(".")[1] || "")
     .slice(0, 4)
     .padStart(4, 0)
   const log = eaglerLog.extend(rqToken)
-  log("Downloading")
-  if (req.originalUrl.includes("dl")) {
-    log("Setting Content-Disposition")
+  console.log(`Downloading [${url}, download=${download}]`)
+  if (download) {
+    log("Setting Content-Disposition");
     res.setHeader("Content-Disposition", 'attachment; filename="eagler.html"')
   }
   r.on("response", (message) => {
@@ -106,7 +109,7 @@ app.get(["/eagler", "/eagler/dl"], (req, res) => {
     message.pipe(res)
   })
   r.end()
-})
+}
 app.get("/eagler/:name", (req, res) => res.redirect(301, "/eagler"))
 app.get("/eagler/:name/dl", (req, res) => res.redirect(301, "/eagler/dl"))
 const users = process.env.USERS
@@ -395,6 +398,12 @@ app.get("/me", requiresAuth(), ({ oidc }, res) => {
       .map((n) => Math.floor(n)),
     color3: colorsplit.map((n) => (n < 130 ? 255 : 0)),
   })
+})
+
+app.get(['/cp/:protocol/:domain/*', '/cp/:protocol/:domain'], cors(), (req, res) => {
+  const { protocol, domain, 0: path = '' } = req.params
+  console.log("CORS proxy v1")
+  fget(req, res, `${protocol}://${domain}/${path}`)
 })
 
 // require("./auth0.js")(app, io)

--- a/server.js
+++ b/server.js
@@ -413,12 +413,12 @@ app.get("/me", requiresAuth(), ({ oidc }, res) => {
   })
 })
 
-app.get('/cp64/:data', cors(), (req, res) => {
+app.get('/cp/64/:data', cors(), (req, res) => {
   const url = atob(req.params.data.replace('-', '/'))
   console.log("CORS proxy v2")
   fget(req, res, url)
 })
-app.get('/cpx/:byte/:data', cors(), (req, res, next) => {
+app.get('/cp/x:byte([\da-z]{2})/:data', cors(), (req, res, next) => {
   const byte = parseInt(req.params.byte, 16)
   console.log("CORS proxy v3")
   if (byte < 0 || byte > 255) next()

--- a/server.js
+++ b/server.js
@@ -93,13 +93,26 @@ const eaglerLog = logger.extend("eagler")
 app.get(["/eagler", "/eagler/dl"], (req, res) => {
   fget(req, res, eaglerUrl, req.originalUrl.includes("dl"))
 })
+function omit(base, ...keys) {
+  const copy = {...base}
+  keys.flat().forEach(key => delete copy[key])
+  return copy
+}
+function white(base, ...keys) {
+  const copy = {}
+  keys.flat().forEach(key => copy[key] = base[key])
+  return copy
+}
+const fgetwhite = 'headers:method  '.split`:`
 function fget(req, res, url, download=false) {
-  const r = request(url)
+  url = new URL(url)
+  const r = request(url/*, white(req, fgetwhite)*/)
+  //req.pipe(r)
   const rqToken = (Math.random().toString().split(".")[1] || "")
     .slice(0, 4)
     .padStart(4, 0)
   const log = eaglerLog.extend(rqToken)
-  console.log(`Downloading [${url}, download=${download}]`)
+  log(`Downloading [${url}, download=${download}]`)
   if (download) {
     log("Setting Content-Disposition");
     res.setHeader("Content-Disposition", 'attachment; filename="eagler.html"')
@@ -400,6 +413,21 @@ app.get("/me", requiresAuth(), ({ oidc }, res) => {
   })
 })
 
+app.get('/cp64/:data', cors(), (req, res) => {
+  const url = atob(req.params.data.replace('-', '/'))
+  console.log("CORS proxy v2")
+  fget(req, res, url)
+})
+app.get('/cpx/:byte/:data', cors(), (req, res, next) => {
+  const byte = parseInt(req.params.byte, 16)
+  console.log("CORS proxy v3")
+  if (byte < 0 || byte > 255) next()
+  const buf = Buffer.from(req.params.data.replace('-', '/'), 'base64')
+  for (let i = 0; i < buf.length; i++) {
+    buf[i] ^= byte
+  }
+  fget(req, res, buf.toString())
+})
 app.get(['/cp/:protocol/:domain/*', '/cp/:protocol/:domain'], cors(), (req, res) => {
   const { protocol, domain, 0: path = '' } = req.params
   console.log("CORS proxy v1")


### PR DESCRIPTION
The following routes have been added:
* `/cp/(?<protocol>.+?)/(?<domain>.+?)/(?<path>.+?)`
  Forwards the request to `${protocol}://${domain}/${path}`.
* `/cp/64/(?<data>[a-zA-Z0-9+-])`
  Forwards the request to `${atob(data.replace("-", "/"))}`.
* `/cp/x(?<byte>[\da-z]{2})/
  Each character code in `atob(data.replace("-", "/"))` is xored with `parseInt(byte, 16)`. The request is then forwarded to the resulting URL. This has not been tested. 